### PR TITLE
CPU: interrupt delay after DMA by 1 cycle (emudetect).

### DIFF
--- a/src/fpga/core/rtl/65C816/P65C816.vhd
+++ b/src/fpga/core/rtl/65C816/P65C816.vhd
@@ -48,9 +48,10 @@ architecture rtl of P65C816 is
 	signal w16 : std_logic;
 	signal DLNoZero : std_logic;
 	signal WAIExec, STPExec : std_logic;
-	signal NMI_SYNC, IRQ_SYNC : std_logic;
+	signal NMI_SYNC : std_logic;
 	signal NMI_ACTIVE, IRQ_ACTIVE : std_logic;
 	signal OLD_NMI_N, OLD_NMI2_N : std_logic;
+	signal RDY_IN_OLD : std_logic;
 	signal ADDR_BUS : std_logic_vector(23 downto 0);
 	
 	-- ALU 
@@ -478,7 +479,6 @@ begin
 		if RST_N = '0' then
 			OLD_NMI_N <= '1';
 			NMI_SYNC <= '0';
-			IRQ_SYNC <= '0';
 		elsif rising_edge(CLK) then
 			if RDY_IN = '1' and CE = '1' and IsResetInterrupt = '0' then
 				OLD_NMI_N <= NMI_N;
@@ -487,13 +487,11 @@ begin
 				elsif LAST_CYCLE = '1' and NMI_SYNC = '1' and EN = '1' then
 					NMI_SYNC <= '0';
 				end if;
-				
-				IRQ_SYNC <= not IRQ_N;
 			end if;
 		end if;
 	end process; 
 	
-	IRQ_ACTIVE <= IRQ_SYNC and not P(2);
+	IRQ_ACTIVE <= not IRQ_N and not P(2);
 	NMI_ACTIVE <= NMI_SYNC;
 	process(CLK, RST_N)
 	begin
@@ -503,7 +501,11 @@ begin
 			IsIRQInterrupt <= '0';
 			GotInterrupt <= '1';
 		elsif rising_edge(CLK) then
-			if RDY_IN = '1' and CE = '1' then
+			if CE = '1' then
+				RDY_IN_OLD <= RDY_IN;
+			end if;
+			
+			if RDY_IN = '1' and RDY_IN_OLD = '1' and CE = '1' then
 				if LAST_CYCLE = '1' and EN = '1' then
 					if GotInterrupt = '0' then
 						GotInterrupt <= IRQ_ACTIVE or NMI_ACTIVE;


### PR DESCRIPTION
This brings the emudetect fix from MiSTer upstream core.